### PR TITLE
Move userAddress to WalletContext

### DIFF
--- a/src/components/admin/Login.tsx
+++ b/src/components/admin/Login.tsx
@@ -12,18 +12,24 @@ import { mainnet } from "viem/chains";
 import { useWallet } from './WalletContext';
 
 export default function LoginSection() {
-  const { connected, setConnected, walletClient, setWalletClient } = useWallet();
-  const [userAddress, setUserAddress] = useState("");
+  const {
+    connected,
+    setConnected,
+    walletClient,
+    setWalletClient,
+    userAddress,
+    setUserAddress,
+  } = useWallet();
   
   async function login(e: any) {
     e.preventDefault();
     try {
       // @ts-ignore
-      await window.ethereum.login();
+      await window.silk.login();
       const newWalletClient = createWalletClient({
         chain: mainnet,
         // @ts-ignore
-        transport: custom(window.ethereum as any),
+        transport: custom(window.silk as any),
       });
       setWalletClient(newWalletClient);
       setConnected(true);
@@ -38,7 +44,7 @@ export default function LoginSection() {
   async function logout(e: React.MouseEvent) {
     e.preventDefault();
     // @ts-ignore
-    window.ethereum = null;
+    // window.silk = null;
     setConnected(false);
     setWalletClient(undefined);
     setUserAddress("");

--- a/src/components/admin/Providers.tsx
+++ b/src/components/admin/Providers.tsx
@@ -18,13 +18,14 @@ type Props = {
 export default function Providers({ children }: Props) {
   const [connected, setConnected] = useState<boolean | undefined>(undefined);
   const [walletClient, setWalletClient] = useState<WalletClient | undefined>(undefined);
-  
+  const [userAddress, setUserAddress] = useState("");
+
   useEffect(() => {
     if (typeof window === "undefined") return;
   
     const silk = initSilk();
     // @ts-ignore
-    window.ethereum = silk;
+    window.silk = silk;
   
     checkConnection();
   }, []);
@@ -32,8 +33,10 @@ export default function Providers({ children }: Props) {
   const checkConnection = async () => {
     try {
       // @ts-ignore
-      const accounts = await window.ethereum.request({ method: 'eth_accounts' });
+      const accounts = await window.silk.request({ method: 'eth_accounts' });
+      console.log('accounts', accounts)
       if (accounts.length > 0) {
+        setUserAddress(accounts[0]);
         setConnected(true);
         initializeWalletClient();
       } else {
@@ -49,13 +52,13 @@ export default function Providers({ children }: Props) {
     const newWalletClient = createWalletClient({
       chain: mainnet,
       // @ts-ignore
-      transport: custom(window.ethereum as any),
+      transport: custom(window.silk as any),
     });
     setWalletClient(newWalletClient);
   };
   
   return (
-    <WalletContext.Provider value={{ connected, setConnected, walletClient, setWalletClient }}>
+    <WalletContext.Provider value={{ connected, setConnected, walletClient, setWalletClient, userAddress, setUserAddress }}>
       <WagmiProvider config={config}>
         <QueryClientProvider client={queryClient}>
           {children}

--- a/src/components/admin/WalletContext.tsx
+++ b/src/components/admin/WalletContext.tsx
@@ -6,6 +6,8 @@ type WalletContextType = {
   setConnected: React.Dispatch<React.SetStateAction<boolean | undefined>>;
   walletClient: WalletClient | undefined;
   setWalletClient: React.Dispatch<React.SetStateAction<WalletClient | undefined>>;
+  userAddress: string;
+  setUserAddress: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);


### PR DESCRIPTION
- Move address to wallet context.
- Use window.silk instead of window.ethereum, to handle case where user an aggressive browser extension wallet.
- Comment out `window.[ethereum|silk] = null`